### PR TITLE
Timeout setting for urldownloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ classes
 deploy
 Iskdaemon_admin
 gwt-unitCache
+.idea

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -29,64 +29,65 @@ logger = logging.getLogger('isk-daemon')
 
 # Defaults
 core = ConfigParser.SafeConfigParser({
-    'startAsDaemon' : 'false',                     # run as background process on UNIX systems
-    'basePort' : '31128',                          # base tcp port to start listening at for HTTP requests (admin interface, XML-RPC requests, etc)
-    'debug' : 'true',                              # print debug messages to console
-    'saveAllOnShutdown' : 'true',                  # automatically save all database spaces on server shutdown
-    'databasePath' : "~/isk-db",                 # file where to store database files
-    'saveInterval' : '120'    ,                    # seconds between each automatic database save
-    'automaticSave' : 'false' ,                    # whether the database should be saved automatically
-    'isClustered' : 'false'   ,                     # run in cluster mode ? If True, make sure subsequent settings are ok
-    'seedPeers' : 'isk2host:31128',                            
-    'bindHostname': 'isk1host' ,                 # hostname for this instance. Other instances may try to connect to this hostname
-    'logPath': 'isk-daemon.log',
-    'logDebug': 'true',
-    })
+	'startAsDaemon': 'false',  # run as background process on UNIX systems
+	'basePort': '31128',  # base tcp port to start listening at for HTTP requests (admin interface, XML-RPC requests, etc)
+	'debug': 'true',  # print debug messages to console
+	'saveAllOnShutdown': 'true',  # automatically save all database spaces on server shutdown
+	'databasePath': "~/isk-db",  # file where to store database files
+	'saveInterval': '120',  # seconds between each automatic database save
+	'automaticSave': 'false',  # whether the database should be saved automatically
+	'isClustered': 'false',  # run in cluster mode ? If True, make sure subsequent settings are ok
+	'seedPeers': 'isk2host:31128',
+	'bindHostname': 'isk1host',  # hostname for this instance. Other instances may try to connect to this hostname
+	'logPath': 'isk-daemon.log',
+	'logDebug': 'true',
+	'urlDownloaderTimeout': '10',  # timeout in seconds for downloading images from web
+})
 
 # read from many possible locations
-conffile = core.read(['isk-daemon.conf', 
-            os.path.expanduser('~/isk-daemon.conf'), 
-            "/etc/iskdaemon/isk-daemon.conf", 
-            #os.path.join(os.environ.get("ISKCONF"),'isk-daemon.conf'),
-            ])
+conffile = core.read(['isk-daemon.conf',
+						os.path.expanduser('~/isk-daemon.conf'),
+						"/etc/iskdaemon/isk-daemon.conf",  # os.path.join(os.environ.get("ISKCONF"),'isk-daemon.conf'),
+])
 
-for sec in ['database', 'daemon','cluster']:
-    if not core.has_section(sec): core.add_section(sec)
+for sec in ['database', 'daemon', 'cluster']:
+	if not core.has_section(sec):
+		core.add_section(sec)
 
 # perform some clean up/bulletproofing
-core.set('database', 'databasePath', os.path.expanduser(core.get('database','databasePath')))
+core.set('database', 'databasePath', os.path.expanduser(core.get('database', 'databasePath')))
 
 # fix windows stuff
-if os.name == 'nt': # fix windows stuff
-    core.set('database', 'databasePath', os.path.expanduser(core.get('database','databasePath').replace('/','\\')))
+if os.name == 'nt':  # fix windows stuff
+	core.set('database', 'databasePath', os.path.expanduser(core.get('database', 'databasePath').replace('/', '\\')))
+
 
 def setupLogging():
-    # set up logging to file - see previous section for more details
-    if core.getboolean('daemon','logDebug'): 
-        llevel = logging.DEBUG
-    else:
-        llevel = logging.INFO
-    logging.basicConfig(level = llevel,
-                        format = '%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
-                        datefmt = '%m-%d %H:%M',
-                        filename = core.get('daemon','logPath'),
-                        )
-    # define a Handler which writes INFO messages or higher to the sys.stderr
-    console = logging.StreamHandler()
-    console.setLevel(logging.DEBUG)  # INFO
-    # set a format which is simpler for console use
-    formatter = logging.Formatter('%(name)-12s: %(levelname)-8s %(message)s')
-    # tell the handler to use this format
-    console.setFormatter(formatter)
-    # add the handler to the root logger
-    logging.getLogger('').addHandler(console)
-    
+	# set up logging to file - see previous section for more details
+	if core.getboolean('daemon', 'logDebug'):
+		llevel = logging.DEBUG
+	else:
+		llevel = logging.INFO
+	logging.basicConfig(level=llevel,
+						format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+						datefmt='%m-%d %H:%M',
+						filename=core.get('daemon', 'logPath'))
+	# define a Handler which writes INFO messages or higher to the sys.stderr
+	console = logging.StreamHandler()
+	console.setLevel(logging.DEBUG)  # INFO
+	# set a format which is simpler for console use
+	formatter = logging.Formatter('%(name)-12s: %(levelname)-8s %(message)s')
+	# tell the handler to use this format
+	console.setFormatter(formatter)
+	# add the handler to the root logger
+	logging.getLogger('').addHandler(console)
+
+
 setupLogging()
 
-
 if len(conffile) < 1:
-    logger.warn('| no config file (isk-daemon.conf) found. Looked at local dir, home user dir and /etc/iskdaemon. Using defaults for everything.')
+	logger.warn('| no config file (isk-daemon.conf) found. Looked at local dir, home user dir and /etc/iskdaemon. Using defaults for everything.')
 else:
-    logger.info('| using config file "%s"' % conffile[0])
+	logger.info('| using config file "%s"' % conffile[0])
 
 

--- a/src/core/urldownloader.py
+++ b/src/core/urldownloader.py
@@ -21,35 +21,40 @@
 #
 ###############################################################################
 
-import urllib2    
+import urllib2
+import settings
 
 urlopen = urllib2.urlopen
 Request = urllib2.Request
 
+
 def urlToFile(theurl, destfile):
-    data = urlData(theurl)
-    if not data: return False
-    
-    f=open(destfile,'wb')
-    f.write(data)
-    f.close()
-    return True
+	data = urlData(theurl)
+	if not data:
+		return False
+
+	f = open(destfile, 'wb')
+	f.write(data)
+	f.close()
+	return True
+
 
 def urlData(theurl):
-    if not theurl: return None
-    if len(theurl) < 12: return None
-    if theurl[:7].lower() != 'http://': return None
-    
-    txdata = None                                                                           # if we were making a POST type request, we could encode a dictionary of values here - using urllib.urlencode
-    txheaders = {'User-agent' : 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.7)', 'Referer' : theurl}
-    
-    try:
-        req = Request(theurl, txdata, txheaders)            # create a request object
-        handle = urlopen(req)                               # and open it to return a handle on the url
-    except:
-        return False
-    else:
-        data = handle.read()
-        return data
-    
-    
+	if not theurl:
+		return None
+	if len(theurl) < 12:
+		return None
+	if theurl[:7].lower() != 'http://':
+		return None
+
+	txdata = None  # if we were making a POST type request, we could encode a dictionary of values here - using urllib.urlencode
+	txheaders = {'User-agent': 'Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.7)', 'Referer': theurl}
+
+	try:
+		req = Request(theurl, txdata, txheaders)  # create a request object
+		timeout = settings.core.getint('daemon', 'urlDownloaderTimeout')
+		handle = urlopen(req, timeout=timeout)  # and open it to return a handle on the url
+		data = handle.read()
+		return data
+	except:
+		return False

--- a/src/core/urldownloader.py
+++ b/src/core/urldownloader.py
@@ -23,9 +23,11 @@
 
 import urllib2
 import settings
+import logging
 
 urlopen = urllib2.urlopen
 Request = urllib2.Request
+rootLog = logging.getLogger('urldownloader')
 
 
 def urlToFile(theurl, destfile):
@@ -56,5 +58,6 @@ def urlData(theurl):
 		handle = urlopen(req, timeout=timeout)  # and open it to return a handle on the url
 		data = handle.read()
 		return data
-	except:
+	except Exception, e:
+		rootLog.error(e)
 		return False


### PR DESCRIPTION
There was problem with urldownloader to freeze when it took too much time to download image. If RPC client used timed out connection at the same time, all isk-daemon instance stops responding.

So, there is new setting urlDownloaderTimeout in [daemon] section. Default value is 10 seconds. It should be kept lower than RCP connection timeout in client scripts.

Also there is logging added to urldownloader exceptions to be more verbose-friendly.

Finally, there are some PEP-8 formatting (and that possibly overwrites spaces with tabs, sorry).
