### PR TITLE
Build on OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ classes
 deploy
 Iskdaemon_admin
 gwt-unitCache
+.idea

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Key features:
 Installation, usage instructions and more details are available online at http://www.imgseek.net/isk-daemon/documents-1/install-and-usage [dead link]
 
 Here are quick guide to build from cloned repo. You may want to ``sudo`` all this commands if you have permission errors.
+I assume you know how to build from source and have all build tools and libraries installed for your system.
 
 ##Ubuntu Quick Start
 
@@ -35,7 +36,7 @@ This one is tested with Ubuntu 14.12
 
 ##MacOS Quick Start
 
-1. Go to http://brew.sh and install Homebrew
+1. Go to http://brew.sh and install ``Homebrew``
 
 2. Install swig: ``brew install swig``
 
@@ -44,6 +45,8 @@ This one is tested with Ubuntu 14.12
 4. Install pkg-config: ``brew install pkg-config``
 
 5. Cd to ./iskdaemon/src/ and run ``python setup.py install``
+
+Alternatively, you can try it with ``macports``.
 
 # Credits
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,31 @@ Key features:
 
 # Install instructions
 
-Installation, usage instructions and more details are available online at http://www.imgseek.net/isk-daemon/documents-1/install-and-usage
+Installation, usage instructions and more details are available online at http://www.imgseek.net/isk-daemon/documents-1/install-and-usage [dead link]
+
+Here are quick guide to build from cloned repo. You may want to ``sudo`` all this commands if you have permission errors.
+
+##Ubuntu Quick Start
+
+This one is tested with Ubuntu 14.12
+
+1. Install prerequisited if they're not on your system already:
+
+    ``apt-get install swig ImageMagick libmagick++-dev python-dev``
+
+2. cd to ./src and run: ``python setup.py install``
+
+##MacOS Quick Start
+
+1. Go to http://brew.sh and install Homebrew
+
+2. Install swig: ``brew install swig``
+
+3. Install ImageMagick: ``brew install ImageMagick``
+
+4. Install pkg-config: ``brew install pkg-config``
+
+5. Cd to ./iskdaemon/src/ and run ``python setup.py install``
 
 # Credits
 

--- a/src/core/imgdbapi.py
+++ b/src/core/imgdbapi.py
@@ -42,7 +42,7 @@ remoteCache = None    # global remote cache (memcached) singleton
 pbFactory = None     # perspective factory
 daemonStartTime = time.time()
 hasShutdown = False
-iskVersion = "0.9.3"
+iskVersion = "0.9.5"
 
 # misc daemon inits
 rootLog = logging.getLogger('imgdbapi')

--- a/src/imgSeekLib/imgdb.cpp
+++ b/src/imgSeekLib/imgdb.cpp
@@ -990,7 +990,7 @@ std::vector<double> queryImgID(const int dbId, long int id, int numres, int sket
 		long int sz = dbSpace[dbId]->sigs.size();
 		int_hashset includedIds;
 		sigIterator it = dbSpace[dbId]->sigs.begin();
-		for (int var = 0; var < min(sz, numres); ) { // var goes from 0 to numres
+		for (int var = 0; var < min<unsigned long>(sz, numres); ) { // var goes from 0 to numres
 			long int rint = rand()%(sz);
 			for(int pqp =0; pqp < rint; pqp++) {
 				it ++;
@@ -1313,7 +1313,7 @@ std::vector<double> queryImgIDKeywords(const int dbId, long int id, int numres, 
 
 		vector<double> Vres;
 
-		for (int var = 0; var < min(V.size()/2, numres); ) { // var goes from 0 to numres
+		for (int var = 0; var < min<unsigned long>(V.size()/2, numres); ) { // var goes from 0 to numres
 			int rint = rand()%(V.size()/2);
 			if (V[rint*2] > 0) { // havent added this random result yet
 				Vres.insert(Vres.end(), V[rint*2] );

--- a/src/installer.nsi
+++ b/src/installer.nsi
@@ -2,7 +2,7 @@
 
 ; HM NIS Edit Wizard helper defines
 !define PRODUCT_NAME "isk-daemon"
-!define PRODUCT_VERSION "0.9.3"
+!define PRODUCT_VERSION "0.9.5"
 !define PRODUCT_PUBLISHER "imgSeek"
 !define PRODUCT_WEB_SITE "http://server.imgseek.net/"
 !define PRODUCT_DIR_REGKEY "Software\Microsoft\Windows\CurrentVersion\App Paths\isk-daemon.exe"

--- a/src/test/test_api.py
+++ b/src/test/test_api.py
@@ -23,6 +23,7 @@
 ###############################################################################
 
 import xmlrpclib
+import os
 
 from optparse import OptionParser
 parser = OptionParser()

--- a/src/ui/admin-gwt/src/net/imgseek/server/admin/client/Iskdaemon_admin.java
+++ b/src/ui/admin-gwt/src/net/imgseek/server/admin/client/Iskdaemon_admin.java
@@ -33,8 +33,8 @@ public class Iskdaemon_admin implements EntryPoint, ValueChangeHandler<String> {
 	private static final String SERVER_ERROR = "An error occurred while "
 			+ "attempting to contact the server. Please check your network "
 			+ "connection and try again.";
-	public static final String VERSION = "0.9.3";
-	public static final String RELEASEDATE = "Jan 2012";
+	public static final String VERSION = "0.9.5";
+	public static final String RELEASEDATE = "Mar 2014";
 	protected static String WEB_ENDPOINT = "/";
 	public static final String XMLRPC_BACKEND = WEB_ENDPOINT + "RPC";
 	protected static SinkList list = new SinkList();


### PR DESCRIPTION
Latest code won't build on OSX: there was no imagemagick include dir found and there were c++ build errors.
Fixed that.

setup.py now detects proper include dir for ImageMagick.
Using subprocess instead of deprecated os.popen.
Fixed c++ build errors according to this issue
ricardocabral#66

Tested on 10.9.5 with Homebrew ImageMagick, swig and pkg-config.
Also tested on fresh Ubuntu server installation.
Updated Readme with quick build info. btw, what happens with your website?
